### PR TITLE
Logs sent to logstash are interpreted as stream and therefore are incorrectly parsed

### DIFF
--- a/lib/winston-logstash.js
+++ b/lib/winston-logstash.js
@@ -137,7 +137,7 @@ Logstash.prototype.sendLog = function (message, callback) {
   var self = this;
   callback = callback || function () {};
 
-  self.socket.write(message);
+  self.socket.write(message + '\n');
   callback();
 };
 

--- a/test/winston-logstash_test.js
+++ b/test/winston-logstash_test.js
@@ -40,13 +40,27 @@ describe('winston-logstash transport', function() {
       done();
     });
 
-    it('send logs over TCP', function(done) {
+    it('send logs over TCP as valid json', function(done) {
+      var response;
+      var logger = createLogger(port);
+      var expected = {"stream":"sample","level":"info","message":"hello world"};
+
+      test_server = createTestServer(port, function (data) {
+        response = data.toString();
+        expect(JSON.parse(response)).to.be.eql(expected);
+        done();
+      });
+
+      logger.log('info', 'hello world', {stream: 'sample'});
+    });
+
+    it('send each log with a new line character', function(done) {
       var response;
       var logger = createLogger(port);
 
       test_server = createTestServer(port, function (data) {
         response = data.toString();
-        expect(response).to.be.equal('{"stream":"sample","level":"info","message":"hello world"}');
+        expect(response).to.be.equal('{"stream":"sample","level":"info","message":"hello world"}\n');
         done();
       });
 


### PR DESCRIPTION
As the socket is not sending a new line with each log message the Logstash server (1.1.12) interpret it as incomplete. This results in all logs sent being interpreted as a single entry when the socket closes.

Fixed by adding a new line to the end of the message to ensure that the logstash server interprets as a complete log message.

I've updated the tests to reflect this.  It might be that previous versions of Logstash server do not have this requirement.
