### PR TITLE
Added ability to configure connection retry count

### DIFF
--- a/lib/winston-logstash.js
+++ b/lib/winston-logstash.js
@@ -15,12 +15,13 @@ var Logstash = exports.Logstash = function (options) {
   winston.Transport.call(this, options);
   options = options || {};
 
-  this.name       = 'logstash';
-  this.localhost  = options.localhost || os.hostname();
-  this.host       = options.host || '127.0.0.1';
-  this.port       = options.port || 28777;
-  this.node_name  = options.node_name || process.title;
-  this.pid        = options.pid || process.pid;
+  this.name                = 'logstash';
+  this.localhost           = options.localhost || os.hostname();
+  this.host                = options.host || '127.0.0.1';
+  this.port                = options.port || 28777;
+  this.node_name           = options.node_name || process.title;
+  this.pid                 = options.pid || process.pid;
+  this.max_connect_retries = options.max_connect_retries || 4;
 
   // Connection state
   this.log_queue = [];
@@ -98,7 +99,7 @@ Logstash.prototype.connect = function () {
   this.socket.on('close', function (had_error) {
     self.connected = false;
 
-    if (self.retries < 4) {
+    if (self.max_connect_retries === -1 || self.retries < self.max_connect_retries) {
       if (!self.connecting) {
         setTimeout(function () {
           self.connect();
@@ -113,6 +114,7 @@ Logstash.prototype.connect = function () {
 
   this.socket.connect(self.port, self.host, function () {
     self.announce();
+    self.connecting = false;
   });
 
 };
@@ -140,22 +142,3 @@ Logstash.prototype.sendLog = function (message, callback) {
   self.socket.write(message + '\n');
   callback();
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Also added an option to never stop trying for daemon processes.

My use case is using node as a logging agent daemon and the winston-logstash needs to be able to reconnect to logstash at any time.

The default retry is still `4` if not configured.
