### PR TITLE
Remove winston dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "type": "git",
     "url": "https://github.com/jaakkos/winston-logstash.git"
   },
+  "peerDependencies": {
+    "winston": ">=0.7.2"
+  },
   "devDependencies": {
     "winston": ">=0.7.2",
     "mocha": ">=1.8.2",


### PR DESCRIPTION
Previously, winston-logstash would install a version of winston into
`node_modules/winston-logstash/node_modules/winston`. If node chooses to
use this version of winston rather than the cached version from
`node_modules/winston`, the consuming application's winston would not have
the Logstash transport attached to it.

This fix removes winston as a dependency, and it is assumed that winston
must be installed by the consumer.
