### PR TITLE
Strip colors from messages and metadata

### DIFF
--- a/lib/winston-logstash.js
+++ b/lib/winston-logstash.js
@@ -37,6 +37,9 @@ var Logstash = exports.Logstash = function (options) {
   this.connected = false;
   this.socket = null;
   this.retries = -1;
+  
+  // Miscellaneous options
+  this.strip_colors         = options.strip_colors || false;
 
   this.connect();
 };
@@ -61,6 +64,17 @@ Logstash.prototype.log = function (level, msg, meta, callback) {
 
   if (self.silent) {
     return callback(null, true);
+  }
+
+  if (self.strip_colors) {
+    msg = msg.stripColors;
+
+    // Let's get rid of colors on our meta properties too.
+    if (typeof meta === 'object') {
+      for (var property in meta) {
+        meta[property] = meta[property].stripColors;
+      }
+    }
   }
 
   log_entry = common.log({


### PR DESCRIPTION
It would be useful to strip out the color escape codes (i.e. `[33m`) from the logs sent to Logstash. It looks like Winston exposes a string transform we can use here to do this: https://github.com/flatiron/winston/blob/ea8bb5b7b2c58274dc128e1942846c8f1c9c19ae/lib/winston/common.js#L129.

Would love to iterate on this if there is a better way; this is my first pass.
