### PR TITLE
Only attempt to strip colors from defined meta properties

### DIFF
--- a/lib/winston-logstash.js
+++ b/lib/winston-logstash.js
@@ -83,7 +83,8 @@ Logstash.prototype.log = function (level, msg, meta, callback) {
     message: msg,
     meta: meta,
     timestamp: self.timestamp,
-    json: true
+    json: true,
+    logstash: true
   });
 
   if (!self.connected) {


### PR DESCRIPTION
This surfaced for me when running mocha tests, my app logs on startup a worker id that's `undefined` in a test env -- It stands to reason that there may be other causes of `undefined`s that will prove hard for implementers to debug. In previous versions these differences failed silently, so this PR maintains that behavior.
