### PR TITLE
Add support for close() method to allow for clean shutdown

### DIFF
--- a/lib/winston-logstash.js
+++ b/lib/winston-logstash.js
@@ -128,6 +128,7 @@ Logstash.prototype.connect = function () {
   var self = this;
   this.retries++;
   this.connecting = true;
+  this.terminating = false;
   if (this.ssl_enable) {
     options = {
       key: this.ssl_key ? fs.readFileSync(this.ssl_key) : null,
@@ -180,9 +181,6 @@ Logstash.prototype.connect = function () {
 
   this.socket.on('close', function (had_error) {
     self.connected = false;
-    if (self.terminating) {
-        return;
-    }
 
     if (self.max_connect_retries < 0 || self.retries < self.max_connect_retries) {
       if (!self.connecting) {
@@ -207,14 +205,14 @@ Logstash.prototype.connect = function () {
 };
 
 Logstash.prototype.close = function () {
-    var self = this;
-    self.terminating = true;
-    if (self.connected && self.socket) {
-        self.connected = false;
-        self.socket.end();
-        self.socket.destroy();
-        self.socket = null;
-    }
+  var self = this;
+  self.terminating = true;
+  if (self.connected && self.socket) {
+    self.connected = false;
+    self.socket.end();
+    self.socket.destroy();
+    self.socket = null;
+  }
 };
 
 Logstash.prototype.announce = function () {
@@ -222,7 +220,7 @@ Logstash.prototype.announce = function () {
   self.connected = true;
   self.flush();
   if (self.terminating) {
-      self.close();
+    self.close();
   }
 };
 

--- a/lib/winston-logstash.js
+++ b/lib/winston-logstash.js
@@ -180,6 +180,9 @@ Logstash.prototype.connect = function () {
 
   this.socket.on('close', function (had_error) {
     self.connected = false;
+    if (self.terminating) {
+        return;
+    }
 
     if (self.max_connect_retries < 0 || self.retries < self.max_connect_retries) {
       if (!self.connecting) {
@@ -203,10 +206,24 @@ Logstash.prototype.connect = function () {
 
 };
 
+Logstash.prototype.close = function () {
+    var self = this;
+    self.terminating = true;
+    if (self.connected && self.socket) {
+        self.connected = false;
+        self.socket.end();
+        self.socket.destroy();
+        self.socket = null;
+    }
+};
+
 Logstash.prototype.announce = function () {
   var self = this;
   self.connected = true;
   self.flush();
+  if (self.terminating) {
+      self.close();
+  }
 };
 
 Logstash.prototype.flush = function () {

--- a/test/winston-logstash_test.js
+++ b/test/winston-logstash_test.js
@@ -207,7 +207,10 @@ describe('winston-logstash transport', function() {
       }, function (data) {
         response = data.toString();
         expect(JSON.parse(response)).to.be.eql(expected);
-        done();
+        if (silence) {
+          done();
+          silence = false;
+        }
       });
 
       logger.transports.logstash.on('error', function (err) {


### PR DESCRIPTION
connection to logstash was causing process to hang on shutdown.  Implemented the close() method, which is called by winston.Logger.close(), to close the connection, which allows the process to shutdown cleanly.