### PR TITLE
Timestamp and failover

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,11 @@
 * `port`
     * The host port to connect.
     * Default: `28777`
+* `hosts`
+    * A list of logstash hosts. This list is cycled until a successful connection is made.
+    * If not specified, `host` and `port` are used instead.
+    * Example: `127.0.0.1:28777,127.0.0.1:28778`
+    * No default. The port part of a host can be specified with the `port` option or defaults to 28777.
 * `max_connect_retries`
     * Max number of attempts to reconnect to logstash before going into silence.
     * `-1` means retry forever.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,3 +34,6 @@
 * `strip_colors`
     * Strip colors from messages and metadata
     * Default: `false`
+* `timestamp`
+    * Add @timestamp field to output message
+    * Default: `false`

--- a/lib/winston-logstash.js
+++ b/lib/winston-logstash.js
@@ -21,8 +21,22 @@ var Logstash = exports.Logstash = function (options) {
 
   this.name                = 'logstash';
   this.localhost           = options.localhost || os.hostname();
-  this.host                = options.host || '127.0.0.1';
-  this.port                = options.port || 28777;
+  if(options.hosts) {
+    this.hosts = options.hosts.split(',').map(function(host) {
+      return {
+        address: host.split(':')[0],
+        port: host.split(':')[1] || options.port || 28777,
+      };
+    });
+  } else {
+    this.hosts = [{
+      address: options.host || '127.0.0.1',
+      port: options.port || 28777
+    }];
+  }
+
+  this.hostIndex           = -1;
+
   this.node_name           = options.node_name || process.title;
   this.pid                 = options.pid || process.pid;
   this.max_connect_retries = ('number' === typeof options.max_connect_retries) ? options.max_connect_retries : 4;
@@ -138,6 +152,9 @@ Logstash.prototype.connect = function () {
   this.retries++;
   this.connecting = true;
   this.terminating = false;
+
+  var host = this.nextHost();
+
   if (this.ssl_enable) {
     options = {
       key: this.ssl_key ? fs.readFileSync(this.ssl_key) : null,
@@ -154,7 +171,7 @@ Logstash.prototype.connect = function () {
         return caFilesList;
       }(this.ca)) : null
     };
-    this.socket = new tls.connect(this.port, this.host, options, function() {
+    this.socket = new tls.connect(host.port, host.address, options, function() {
       self.socket.setEncoding('UTF-8');
       self.announce();
       self.connecting = false;
@@ -206,12 +223,17 @@ Logstash.prototype.connect = function () {
   });
 
   if (!this.ssl_enable) {
-    this.socket.connect(self.port, self.host, function () {
+    this.socket.connect(host.port, host.address, function () {
       self.announce();
       self.connecting = false;
     });
   }
 
+};
+
+Logstash.prototype.nextHost = function() {
+  this.hostIndex = this.hostIndex + 1 % this.hosts.length;
+  return this.hosts[this.hostIndex];
 };
 
 Logstash.prototype.close = function () {

--- a/lib/winston-logstash.js
+++ b/lib/winston-logstash.js
@@ -50,6 +50,7 @@ var Logstash = exports.Logstash = function (options) {
   this.strip_colors        = options.strip_colors || false;
   this.label               = options.label || this.node_name;
   this.meta_defaults       = options.meta || {};
+  this.timestamp           = options.timestamp || false;
 
   // We want to avoid copy-by-reference for meta defaults, so make sure it's a flat object.
   for (var property in this.meta_defaults) {
@@ -98,14 +99,20 @@ Logstash.prototype.log = function (level, msg, meta, callback) {
     }
   }
 
+  if (self.timestamp) {
+    meta['@timestamp'] = common.timestamp();
+  }
+
+  if (this.label) {
+    meta.label = this.label;
+  }
+
   log_entry = common.log({
     level: level,
     message: msg,
     node_name: this.node_name,
     meta: meta,
-    timestamp: self.timestamp,
-    json: true,
-    label: this.label
+    raw: true,
   });
 
   if (!self.connected) {

--- a/lib/winston-logstash.js
+++ b/lib/winston-logstash.js
@@ -232,7 +232,7 @@ Logstash.prototype.connect = function () {
 };
 
 Logstash.prototype.nextHost = function() {
-  this.hostIndex = this.hostIndex + 1 % this.hosts.length;
+  this.hostIndex = (this.hostIndex + 1) % this.hosts.length;
   return this.hosts[this.hostIndex];
 };
 


### PR DESCRIPTION
1. Set `@timestamp` on log message instead of letting logstash set the timestamp. This will get you a more precise timestamp because of eg network latency or logstash is down for a long time.
2. If connection is lost to logstash host, reconnect to the next host in the list until a connection is successfully made or `max_connect_retries` is reached.
