### PR TITLE
Clean disconnects

### DIFF
--- a/lib/winston-logstash.js
+++ b/lib/winston-logstash.js
@@ -185,6 +185,9 @@ Logstash.prototype.connect = function () {
   this.socket.on('close', function (had_error) {
     self.connected = false;
 
+    if (self.terminating) {
+      return;
+    }
     if (self.max_connect_retries < 0 || self.retries < self.max_connect_retries) {
       if (!self.connecting) {
         setTimeout(function () {
@@ -232,7 +235,6 @@ Logstash.prototype.flush = function () {
 
   for (var i = 0; i < self.log_queue.length; i++) {
     self.sendLog(self.log_queue[i].message, self.log_queue[i].callback);
-    self.emit('logged');
   }
   self.log_queue.length = 0;
 };
@@ -243,4 +245,8 @@ Logstash.prototype.sendLog = function (message, callback) {
 
   self.socket.write(message + '\n');
   callback();
+};
+
+Logstash.prototype.getQueueLength = function () {
+  return this.log_queue.length;
 };


### PR DESCRIPTION
'logged' was getting fired from flush(), but the event is already in the callback that's pushed. Reconnect was triggering even after an explicit close() call, so I avoid that if self.terminating is true. And finally, allow retrieval of the queue length to allow "draining" the existing messages before shutting down the socket. Still not super clean because of the way the queue counts work, so a clean shutdown looks like:

```
      const logTransport = winston.default.transports.logstash;
      let queued = logTransport.getQueueLength();

      if (queued > 0) {
        logTransport.on('logged', () => {
          if (--queued === 1) {
            process.nextTick(() => {
              winston.remove(logTransport);
            });
          }
        });
      } else {
        winston.remove(logTransport);
      }
```