### PR TITLE
Add setKeepAlive for net.socket

### DIFF
--- a/lib/winston-logstash.js
+++ b/lib/winston-logstash.js
@@ -199,6 +199,7 @@ Logstash.prototype.connect = function () {
     this.socket.connect(self.port, self.host, function () {
       self.announce();
       self.connecting = false;
+      self.socket.setKeepAlive(true, 60 * 1000);
     });
   }
 


### PR DESCRIPTION
* Prevent `Error: read ECONNRESET` when using net.socket by using
setKeepAlive when connecting.
* Use an `initialDelay` of 60 seconds.

Net -> socket.setKeepAlive:
https://nodejs.org/api/net.html#net_socket_setkeepalive_enable_initialdelay

Closes #38, #41 

This can be tested by installing [@bstream/winston-logstash@0.3.1](https://www.npmjs.com/package/@bstream/winston-logstash)