### PR TITLE
Do not access socket after closing

### DIFF
--- a/lib/winston-logstash.js
+++ b/lib/winston-logstash.js
@@ -199,7 +199,9 @@ Logstash.prototype.connect = function () {
     this.socket.connect(self.port, self.host, function () {
       self.announce();
       self.connecting = false;
-      self.socket.setKeepAlive(true, 60 * 1000);
+      if (!self.terminating) {
+        self.socket.setKeepAlive(true, 60 * 1000);
+      }
     });
   }
 


### PR DESCRIPTION
If the logger is closed before the socket connects, this error is
raised.

```
TypeError: Cannot read property 'setKeepAlive' of null
    at Socket.<anonymous>
(/home/tarn/projects/logstash-winston/node_modules/winston-logstash/lib/winston-logstash.js:203:19)
    at Object.onceWrapper (events.js:286:20)
    at Socket.emit (events.js:203:15)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1093:10)
```

This commit prevents this happening if the socket it terminating.