### PR TITLE
fixes Manager failing to properly remove event listeners from Connection

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -19,9 +19,16 @@ class Manager extends _events.EventEmitter {
     _defineProperty(this, "maxConnectRetries", void 0);
     _defineProperty(this, "timeoutConnectRetries", void 0);
     _defineProperty(this, "retryTimeout", undefined);
+    _defineProperty(this, "connectionCallbacks", new Map());
     this.options = options;
     this.connection = connection;
     this.logQueue = new Array();
+    this.connectionCallbacks.set(_connection.ConnectionEvents.Connected, this.onConnected.bind(this));
+    this.connectionCallbacks.set(_connection.ConnectionEvents.Closed, this.onConnectionClosed.bind(this));
+    this.connectionCallbacks.set(_connection.ConnectionEvents.ClosedByServer, this.onConnectionError.bind(this));
+    this.connectionCallbacks.set(_connection.ConnectionEvents.Error, this.onConnectionError.bind(this));
+    this.connectionCallbacks.set(_connection.ConnectionEvents.Timeout, this.onConnectionError.bind(this));
+    this.connectionCallbacks.set(_connection.ConnectionEvents.Drain, this.flush.bind(this));
 
     // Connection retry attributes
     this.retries = 0;
@@ -29,20 +36,20 @@ class Manager extends _events.EventEmitter {
     this.timeoutConnectRetries = (_options$timeout_conn = options === null || options === void 0 ? void 0 : options.timeout_connect_retries) !== null && _options$timeout_conn !== void 0 ? _options$timeout_conn : 100;
   }
   addEventListeners() {
-    this.connection.once(_connection.ConnectionEvents.Connected, this.onConnected.bind(this));
-    this.connection.once(_connection.ConnectionEvents.Closed, this.onConnectionClosed.bind(this));
-    this.connection.once(_connection.ConnectionEvents.ClosedByServer, this.onConnectionError.bind(this));
-    this.connection.once(_connection.ConnectionEvents.Error, this.onConnectionError.bind(this));
-    this.connection.once(_connection.ConnectionEvents.Timeout, this.onConnectionError.bind(this));
-    this.connection.on(_connection.ConnectionEvents.Drain, this.flush.bind(this));
+    this.connection.once(_connection.ConnectionEvents.Connected, this.connectionCallbacks.get(_connection.ConnectionEvents.Connected));
+    this.connection.once(_connection.ConnectionEvents.Closed, this.connectionCallbacks.get(_connection.ConnectionEvents.Closed));
+    this.connection.once(_connection.ConnectionEvents.ClosedByServer, this.connectionCallbacks.get(_connection.ConnectionEvents.ClosedByServer));
+    this.connection.once(_connection.ConnectionEvents.Error, this.connectionCallbacks.get(_connection.ConnectionEvents.Error));
+    this.connection.once(_connection.ConnectionEvents.Timeout, this.connectionCallbacks.get(_connection.ConnectionEvents.Timeout));
+    this.connection.on(_connection.ConnectionEvents.Drain, this.connectionCallbacks.get(_connection.ConnectionEvents.Drain));
   }
   removeEventListeners() {
-    this.connection.off(_connection.ConnectionEvents.Connected, this.onConnected.bind(this));
-    this.connection.off(_connection.ConnectionEvents.Closed, this.onConnectionClosed.bind(this));
-    this.connection.off(_connection.ConnectionEvents.ClosedByServer, this.onConnectionError.bind(this));
-    this.connection.off(_connection.ConnectionEvents.Error, this.onConnectionError.bind(this));
-    this.connection.off(_connection.ConnectionEvents.Timeout, this.onConnectionError.bind(this));
-    this.connection.off(_connection.ConnectionEvents.Drain, this.flush.bind(this));
+    this.connection.off(_connection.ConnectionEvents.Connected, this.connectionCallbacks.get(_connection.ConnectionEvents.Connected));
+    this.connection.off(_connection.ConnectionEvents.Closed, this.connectionCallbacks.get(_connection.ConnectionEvents.Closed));
+    this.connection.off(_connection.ConnectionEvents.ClosedByServer, this.connectionCallbacks.get(_connection.ConnectionEvents.ClosedByServer));
+    this.connection.off(_connection.ConnectionEvents.Error, this.connectionCallbacks.get(_connection.ConnectionEvents.Error));
+    this.connection.off(_connection.ConnectionEvents.Timeout, this.connectionCallbacks.get(_connection.ConnectionEvents.Timeout));
+    this.connection.off(_connection.ConnectionEvents.Drain, this.connectionCallbacks.get(_connection.ConnectionEvents.Drain));
   }
   onConnected() {
     this.emit('connected');


### PR DESCRIPTION
I believe there is a memory leak in the handling of event listeners in the Manager class.  
The callbacks registered on the Connection object in the **addEventListeners** method are improperly removed in the **removeEventListeners** method.  
The references to the callbacks are lost because they are modified by a call to the **bind** method.  Each call to **bind** creates a new reference, [see](https://stackoverflow.com/questions/11565471/removing-event-listener-which-was-added-with-bind).