### PR TITLE
Add exponential backoff retry strategy as default and fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,20 +112,6 @@ logger.on('error', (error) => {
 
 See documentation from [docs/configuration](docs/configuration.md)
 
-### How to keep the connection open while Logstash is restarting?
-
-It's possible to set max_connect_retries to -1 (infinite) so the client keeps trying to connect to the Logstash. So when Logstash is restarted the retry logic will reconnect when it comes back online.
-
-``` js
-    const logger = winston.createLogger({
-      transports: [
-        new LogstashTransport({
-              ...
-               max_connect_retries: -1
-              ...
-              })]});
-```
-
 ## Run Tests
 
 ```shell

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,13 +6,15 @@
 * `port`
   * The host port to connect.
   * Default: `28777`
-* `max_connect_retries`
-  * Max number of attempts to reconnect to logstash before going into silence.
-  * `-1` means retry forever.
-  * Default: `4`
-* `timeout_connect_retries`
-  * The number of ms between each retry for a reconnect to logstash .
-  * Default: `100`
+* `retryStrategy`
+  * What strategy to use to retry when the connection encounters an error.
+  * Consists of an object in one of two formats:
+    * Exponential backoff: start with a short timeout, and then retry with a longer timeout with each failure.
+      * `{ strategy: 'exponentialBackoff', maxConnectRetries: number, maxDelayBeforeRetryMs: number }`
+    * Fixed delay: retry after a fixed delay each time.
+      * `{ strategy: 'fixedDelay', maxConnectRetries: number, delayBeforeRetryMs: number }`
+  * You can set `maxConnectRetries: -1` to have no limit on the number of retries.
+  * Default `{ strategy: 'exponentialBackoff', maxConnectRetries: -1, maxDelayBeforeRetryMs: 120000 }`
 * `ssl_enable`
   * Enable SSL transfer of logs to logstash.
   * Default: `false`

--- a/src/__mocks__/connection.ts
+++ b/src/__mocks__/connection.ts
@@ -1,0 +1,47 @@
+const connectionModule = jest.requireActual('../connection');
+
+class PlainConnection {
+  listeners: { [eventName: string]: EventCallback[] } = {};
+  onceListeners: { [eventName: string]: EventCallback[] } = {};
+
+  connect() {}
+  close() {}
+  send() {
+    return true;
+  }
+  readyToSend() {
+    return true;
+  }
+
+  once(eventName: string, callback: EventCallback) {
+    const onceListeners = this.onceListeners[eventName] || [];
+    onceListeners.push(callback);
+    this.onceListeners[eventName] = onceListeners;
+  }
+
+  on(eventName: string, callback: EventCallback) {
+    const listeners = this.listeners[eventName] || [];
+    listeners.push(callback);
+    this.listeners[eventName] = listeners;
+  }
+
+  off(eventName: string, callback: EventCallback) {
+    const listeners = this.listeners[eventName] || [];
+    this.listeners[eventName] = listeners.filter((l) => l !== callback);
+    const onceListeners = this.listeners[eventName] || [];
+    this.onceListeners[eventName] = onceListeners.filter((l) => l !== callback);
+  }
+
+  emit(eventName: string, ...args: any[]) {
+    const onceListeners = this.onceListeners[eventName] || [];
+    const listeners = this.listeners[eventName] || [];
+    this.onceListeners[eventName] = [];
+    for (const listener of [...listeners, ...onceListeners]) {
+      listener(...args);
+    }
+  }
+}
+
+type EventCallback = (...args: any[]) => void;
+
+module.exports = { ...connectionModule, PlainConnection };

--- a/src/manager.test.ts
+++ b/src/manager.test.ts
@@ -1,17 +1,14 @@
-import { Manager } from './manager';
-import { Connection, ConnectionEvents, PlainConnection, SecureConnection } from './connection';
+import { Manager} from './manager';
+import { ConnectionEvents, PlainConnection } from './connection';
+import { LogstashTransportOptions, RetryStrategy } from "./types";
 
 jest.mock('./connection');
 
 const MockedPlainConnection = PlainConnection as jest.MockedClass<typeof PlainConnection>;
-const MockedSecureConnection = SecureConnection as jest.MockedClass<typeof SecureConnection>;
 
 describe('Manager', () => {
-  let manager: Manager;
   let connection: PlainConnection;
-  const options = {
-    host: 'localhost',
-    port: 12345,
+  const defaultOptions: LogstashTransportOptions = {
     ssl_enable: false,
     max_connect_retries: 4,
     timeout_connect_retries: 100
@@ -19,8 +16,7 @@ describe('Manager', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
-    connection = new MockedPlainConnection(options);
-    manager = new Manager(options, connection);
+    connection = new MockedPlainConnection({ host: 'localhost', port: 12345 });
     connection.send = jest.fn().mockReturnValue(true);
     connection.readyToSend = jest.fn().mockReturnValue(true);
   });
@@ -30,15 +26,20 @@ describe('Manager', () => {
   });
 
   test('initializes with provided options', () => {
-    expect(manager['options']).toBe(options);
-    expect(manager['maxConnectRetries']).toBe(options.max_connect_retries);
-    expect(manager['timeoutConnectRetries']).toBe(options.timeout_connect_retries);
+    const manager = new Manager(defaultOptions, connection);
+    expect(manager['options']).toBe(defaultOptions);
+    expect(manager["retryStrategy"]).toEqual<RetryStrategy>({
+      strategy: "fixedDelay",
+      delayBeforeRetryMs: defaultOptions.timeout_connect_retries!,
+      maxConnectRetries: defaultOptions.max_connect_retries!,
+    });
   });
 
   test('logs an entry', () => {
+    const manager = new Manager(defaultOptions, connection);
     const logEntry = 'test log entry';
     const callback = jest.fn();
-    
+
     manager.log(logEntry, callback);
 
     expect(manager['logQueue']).toHaveLength(1);
@@ -46,6 +47,7 @@ describe('Manager', () => {
   });
 
   test('flushes log queue', () => {
+    const manager = new Manager(defaultOptions, connection);
     const logEntry = 'test log entry';
     const callback = jest.fn();
     manager['logQueue'].push([logEntry, callback]);
@@ -57,43 +59,80 @@ describe('Manager', () => {
   });
 
   test('should emit events when connection methods are called', () => {
+    const manager = new Manager(defaultOptions, connection);
     const mockEventEmit = jest.spyOn(manager, 'emit');
 
     manager['onConnected']();
-    expect(mockEventEmit).toHaveBeenCalledWith('connected');
-
+    expect(mockEventEmit).toHaveBeenCalledWith('flushing');
     mockEventEmit.mockClear();
 
-    // @ts-ignore
-    manager.onConnectionClosed(new Error());
+    manager['onConnectionClosed'](new Error());
     expect(mockEventEmit).toHaveBeenCalledWith('closed');
-
   });
 
   test('should stop retrying after max retries are reached', () => {
+    const manager = new Manager(defaultOptions, connection);
+
+    // Set the number of retries to the max.
+    manager['retries'] = manager['retryStrategy']['maxConnectRetries'];
+    // Add connection listeners.
+    manager.start();
+
+    // Handle manager errors so no unhandled errors stop the test.
+    let receivedError: Error | null = null;
+    manager.on('error', (error) => {
+      receivedError = error;
+    });
+
+    // Trigger an error on the connection.
     const spyOnStart = jest.spyOn(manager, 'start');
     const error = new Error('Test error');
-  
-    // Set the number of retries to the max.
-    manager['retries'] = manager['maxConnectRetries'];
-  
-    // Trigger an error on the connection.
     connection.emit(ConnectionEvents.Error, error);
-  
+
     jest.runAllTimers();
-  
+
     // Check that the manager's start method was not called.
     expect(spyOnStart).not.toHaveBeenCalled();
+    expect(receivedError).not.toBeNull();
   });
-  
+
+  test('should retry with exponential backoff', () => {
+    const manager = new Manager({
+      ssl_enable: false,
+      retryStrategy: { strategy: 'exponentialBackoff', maxConnectRetries: -1 },
+    }, connection);
+
+    // Add connection listeners.
+    manager.start();
+
+    // Trigger an error on the connection.
+    const spyOnStart = jest.spyOn(manager, 'start');
+    const error = new Error('Test error');
+
+    connection.emit(ConnectionEvents.Error, error);
+    connection.emit(ConnectionEvents.Closed);
+    jest.advanceTimersByTime(100);
+    expect(spyOnStart).toHaveBeenCalledTimes(1);
+
+    connection.emit(ConnectionEvents.Error, error);
+    connection.emit(ConnectionEvents.Closed);
+    jest.advanceTimersByTime(200);
+    expect(spyOnStart).toHaveBeenCalledTimes(2);
+
+    connection.emit(ConnectionEvents.Error, error);
+    connection.emit(ConnectionEvents.Closed);
+    jest.advanceTimersByTime(400);
+    expect(spyOnStart).toHaveBeenCalledTimes(3);
+  });
+
   test('should close the manager', () => {
+    const manager = new Manager(defaultOptions, connection);
     const spyOnClose = jest.spyOn(connection, 'close');
     const spyOnEmit = jest.spyOn(manager, 'emit');
-  
+
     manager.close();
-  
+
     expect(spyOnEmit).toHaveBeenCalledWith('closing');
     expect(spyOnClose).toHaveBeenCalled();
   });
-  
 });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -23,7 +23,37 @@ interface LogstashTransportOptions extends GenericTransportOptions,
   node_name?: string;
   meta?: Object
   ssl_enable?: Boolean;
-  retries?: number;
+
+  /**
+   * How to retry on connection failure. We can either retry immediately or
+   * after a delay
+   */
+  retryStrategy?: RetryStrategy;
+
+  /** @deprecated - Use `retryStrategy` instead */
   max_connect_retries?: number;
+  /** @deprecated - Use `retryStrategy` instead */
   timeout_connect_retries?: number;
+}
+
+export type RetryStrategy = BackoffRetryStrategy | FixedDelayRetryStrategy;
+
+interface BackoffRetryStrategy extends BaseRetryStrategy {
+  strategy: 'exponentialBackoff';
+  /**
+   * Limit the delay so we don't wait a really long time if a lot of retries
+   * have failed.
+   */
+  maxDelayBeforeRetryMs: number;
+}
+
+interface FixedDelayRetryStrategy extends BaseRetryStrategy {
+  strategy: 'fixedDelay',
+  /** How long to wait before each retry */
+  delayBeforeRetryMs: number;
+}
+
+interface BaseRetryStrategy {
+  /** How many times to retry before fully giving up. -1 for unlimited */
+  maxConnectRetries: number;
 }


### PR DESCRIPTION
## Motivation

I realized that the default setting of winston-logstash caused it to retry 4 times within 400ms, and then never retry again. For most production services, I think this is not the ideal default.

I thought about just changing this to retry infinitely, but reconnecting every 100ms seems a bit excessive, especially if the server is currently down.

## Fix

1. Refactor the retry options into a single `retryStrategy` option, while maintaining backwards compatibility with the old options
2. Add support for `exponentialBackoff` strategy, where we start with a 100ms delay, but double it each time. This allows us to reconnect quickly in most cases, but avoid hammering the server if it's overloaded
3. Refactor tests to make them work properly
   - I realized the old tests for the retry logic didn't actually test anything! None of the retry functions were getting called since it was using a stubbed out connection class
   - Created a new mock PlainConnection that properly handles events
   - Used that in the tests to test the new retry logic

## Testing

1. Added automated tests
2. Installed package and verified logging restarted successfully after disconnecting Internet from my local machine