### PR TITLE
ci: bump actions/setup-node from 6 to 7

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -25,7 +25,7 @@ jobs:
         working-directory: ./test-bench/logstash/
         run: docker compose -f "docker-compose.yml" up -d
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install base project deps

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary
- Bumps `actions/setup-node` from v6 to v7 in build, integration, and release workflows
- Same change as Dependabot #155 (closed) — pushed via SSH because the OAuth app cannot merge workflow-file PRs without `workflow` scope

## Test plan
- [ ] CI build matrix green
- [ ] Integration tests green